### PR TITLE
Remove call to vTaskDelay

### DIFF
--- a/node/main/mtftp_task.cpp
+++ b/node/main/mtftp_task.cpp
@@ -31,7 +31,7 @@ enum state {
 
 struct {
   uint8_t peer_addr[6];
-  int8_t buffered_tx;
+  volatile int8_t buffered_tx;
   enum state state;
 
   uint16_t file_index;
@@ -153,9 +153,7 @@ static bool readFile(uint16_t file_index, uint32_t file_offset, uint8_t *data, u
 }
 
 static void sendEspNow(const uint8_t *data, uint8_t len) {
-  while (local_state.buffered_tx > MAX_BUFFERED_TX) {
-    vTaskDelay(1);
-  }
+  while (local_state.buffered_tx > MAX_BUFFERED_TX);
 
   ESP_ERROR_CHECK(esp_now_send((const uint8_t *) local_state.peer_addr, data, len));
   local_state.buffered_tx ++;


### PR DESCRIPTION
Since the buffered packets appear to be sent within 10ms (length of one FreeRTOS tick), looping instead of delaying improves performance further