### PR TITLE
Integrate sampling task

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -177,6 +177,12 @@ bool get_file_size(uint16_t file_index, uint32_t *size) {
   return true;
 }
 
+uint64_t get_time(void) {
+  struct timeval tv_now;
+  gettimeofday(&tv_now, NULL);
+  return (uint64_t) tv_now.tv_sec * 1000000L + (uint64_t) tv_now.tv_usec;
+}
+
 esp_err_t espnow_add_peer(const uint8_t *peer_addr) {
   esp_now_peer_info_t peer;
   memset(&peer, 0, sizeof(esp_now_peer_info_t));

--- a/common/include/board.h
+++ b/common/include/board.h
@@ -5,16 +5,17 @@
 const spi_host_device_t SENSOR_SPI_HOST = SPI2_HOST;
 const uint32_t SENSOR_SPI_SPEED = 1000000;
 
-const gpio_num_t GPIO_SPI_SCLK = GPIO_NUM_27;
-const gpio_num_t GPIO_SPI_MISO = GPIO_NUM_26;
-const gpio_num_t GPIO_SPI_MOSI = GPIO_NUM_25;
+const gpio_num_t GPIO_SPI_SCLK   = GPIO_NUM_27;
+const gpio_num_t GPIO_SPI_MISO   = GPIO_NUM_26;
+const gpio_num_t GPIO_SPI_MOSI   = GPIO_NUM_25;
 const gpio_num_t GPIO_SPI_CS_ADC = GPIO_NUM_23;
 const gpio_num_t GPIO_SPI_CS_BME = GPIO_NUM_22;
 
-const gpio_num_t GPIO_POWER_SEL = GPIO_NUM_18;
+const gpio_num_t GPIO_POWER_SEL  = GPIO_NUM_18;
 
-const gpio_num_t GPIO_LED = GPIO_NUM_5;
-const gpio_num_t GPIO_BTN_USER = GPIO_NUM_39;
+const gpio_num_t GPIO_LED        = GPIO_NUM_5;
+const gpio_num_t GPIO_BTN_USER   = GPIO_NUM_39;
 
-const gpio_num_t GPIO_UART1_TXD = GPIO_NUM_21;
-const gpio_num_t GPIO_UART1_RXD = GPIO_NUM_19;
+const gpio_num_t GPIO_UART1_TXD  = GPIO_NUM_21;
+const gpio_num_t GPIO_UART1_RXD  = GPIO_NUM_19;
+const gpio_num_t GPIO_GPS_PPS    = GPIO_NUM_34;

--- a/common/include/common.h
+++ b/common/include/common.h
@@ -26,6 +26,8 @@ int get_btn_user(void);
 bool conv_strtoul(char *str, uint16_t *num);
 bool get_file_size(uint16_t file_index, uint32_t *size);
 
+uint64_t get_time(void);
+
 esp_err_t espnow_add_peer(const uint8_t *peer_addr);
 // two separate functions for setting addr/sending data so that
 // caller of sendEspNow dosent need to know the address

--- a/node/main/Kconfig.projbuild
+++ b/node/main/Kconfig.projbuild
@@ -19,8 +19,8 @@ config SAMPLE_PERIOD
     Period of sensor sampling
 config SAMPLE_BUFFER_NUM
     int "Number of samples to buffer"
-    default 128
-    range 1 1024
+    default 512
+    range 1 32768
     help
     Two buffers will be allocated to each hold SAMPLE_BUFFER_NUM amount of samples
 endmenu

--- a/node/main/main.cpp
+++ b/node/main/main.cpp
@@ -28,5 +28,5 @@ void app_main(void) {
 
   xTaskCreate(mtftp_task, "mtftp_task", 8192, NULL, 4, NULL);
   xTaskCreate(sample_task, "sample_task", 4096, NULL, 10, NULL);
-  // xTaskCreate(time_sync_task, "time_sync_task", 4096, NULL, 4, NULL);
+  xTaskCreate(time_sync_task, "time_sync_task", 4096, NULL, 4, NULL);
 }

--- a/node/main/main.cpp
+++ b/node/main/main.cpp
@@ -20,17 +20,13 @@ extern "C" {
 void app_main(void) {
   hw_init();
 
-  // nvs_init();
-  // wifi_init();
-  // espnow_init();
+  nvs_init();
+  wifi_init();
+  espnow_init();
 
-  // sd_init();
+  sd_init();
 
-  aux_activate();
-
-  vTaskDelay(50);
-
-  // xTaskCreatePinnedToCore(mtftp_task, "mtftp_task", 8192, NULL, 4, NULL, 1);
+  xTaskCreate(mtftp_task, "mtftp_task", 8192, NULL, 4, NULL);
   xTaskCreate(sample_task, "sample_task", 4096, NULL, 10, NULL);
   // xTaskCreate(time_sync_task, "time_sync_task", 4096, NULL, 4, NULL);
 }

--- a/node/main/sample_task.cpp
+++ b/node/main/sample_task.cpp
@@ -166,9 +166,7 @@ void sample_task(void *pvParameter) {
       float val = sensor_read();
       *(((float *) sample_buffers[cur_buf]) + sample_count[cur_buf]) = val;
       if (sample_count[cur_buf] == 0) {
-        struct timeval tv_now;
-        gettimeofday(&tv_now, NULL);
-        sample_start_time[cur_buf] = (uint64_t) tv_now.tv_sec * 1000000L + (uint64_t) tv_now.tv_usec;
+        sample_start_time[cur_buf] = get_time();
       }
 
       sample_count[cur_buf] ++;

--- a/node/main/sample_task.h
+++ b/node/main/sample_task.h
@@ -1,6 +1,24 @@
 #ifndef SAMPLE_H
 #define SAMPLE_H
 
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
 void sample_task(void *pvParameter);
+
+// this is used to protect access to the file with index sample_file_index
+// because mtftp_task and sample_task could both access it at the same time
+// eg when a transfer is going on (reading from this file) and
+//   sample_task needs to write samples to file
+
+/*
+  sample_file_semaph is used to lock access to sample_file_index
+  this works fine if (time to transmit sample_file_index) < (time to fill one buffer).
+  to fix, probably can make the semaphorewait timeout and write to sample_file_index + 1 instead
+*/
+
+extern uint16_t sample_file_index;
+extern SemaphoreHandle_t sample_file_semaph;
 
 #endif

--- a/node/main/sample_task.h
+++ b/node/main/sample_task.h
@@ -21,4 +21,6 @@ void sample_task(void *pvParameter);
 extern uint16_t sample_file_index;
 extern SemaphoreHandle_t sample_file_semaph;
 
+extern SemaphoreHandle_t time_acquired_semaph;
+
 #endif

--- a/node/main/time_sync_task.cpp
+++ b/node/main/time_sync_task.cpp
@@ -8,6 +8,7 @@
 #include <sys/time.h>
 
 #include "board.h"
+#include "common.h"
 
 static QueueHandle_t uart_queue;
 static const int UART_NUM = UART_NUM_2;
@@ -16,8 +17,52 @@ static const int LEN_BUF_RX = 256;
 static const int LEN_BUF_READ = 128;
 static const int QUEUE_LEN = 8;
 
+static const int ESP_INTR_FLAG_DEFAULT = 0;
+
+// system time where next_time was configured
+static int64_t next_time_arrival = -10000000;
+// absolute time, valid on next pps pulse
+static struct timeval next_time;
+
+static QueueHandle_t queue_handle;
+static void IRAM_ATTR pps_isr_handler(void *arg) {
+  // sanity check that the value of next_time was set within the last second
+  if ((esp_timer_get_time() - next_time_arrival) > 950000) return;
+
+  uint64_t time = get_time();
+  xQueueSendFromISR(queue_handle, &time, 0);
+
+  settimeofday(&next_time, NULL);
+}
+
+static void logging_task(void *pvParameter) {
+  const char *TAG = "logging_task";
+  uint64_t time;
+
+  queue_handle = xQueueCreate(4, sizeof(uint64_t));
+
+  while(1) {
+    if (xQueueReceive(queue_handle, &time, 1050 / portTICK_PERIOD_MS) == pdTRUE) {
+      ESP_LOGI(TAG, "pulse: %llu", time);
+    }
+  }
+}
+
+static void pps_init(void) {
+  ESP_ERROR_CHECK(gpio_set_direction(GPIO_GPS_PPS, GPIO_MODE_INPUT));
+  ESP_ERROR_CHECK(gpio_intr_enable(GPIO_GPS_PPS));
+  ESP_ERROR_CHECK(gpio_set_intr_type(GPIO_GPS_PPS, GPIO_INTR_POSEDGE));
+  ESP_ERROR_CHECK(gpio_set_pull_mode(GPIO_GPS_PPS, GPIO_PULLDOWN_ONLY));
+
+  ESP_ERROR_CHECK(gpio_install_isr_service(ESP_INTR_FLAG_DEFAULT));
+  ESP_ERROR_CHECK(gpio_isr_handler_add(GPIO_GPS_PPS, pps_isr_handler, NULL));
+  xTaskCreate(logging_task, "logging_task", 2048, NULL, 3, NULL);
+}
+
 void time_sync_task(void *pvParameter) {
   const char *TAG = "time-sync";
+
+  pps_init();
 
   uart_config_t uart_config;
   memset(&uart_config, 0, sizeof(uart_config_t));
@@ -92,16 +137,13 @@ void time_sync_task(void *pvParameter) {
               _tm.tm_mday = day;
               _tm.tm_hour = time / 10000;
               _tm.tm_min = (time / 100) % 100;
-              _tm.tm_sec = time % 100;
+              // + 1 because the next pps edge is the next second
+              _tm.tm_sec = (time % 100) + 1;
 
               time_t t = mktime(&_tm);
+              next_time.tv_sec = t;
 
-              ESP_LOGI(TAG, "set time to %s", asctime(&_tm));
-
-              struct timeval now;
-              now.tv_sec = t;
-
-              settimeofday(&now, NULL);
+              next_time_arrival = esp_timer_get_time();
             }
           } else {
             ESP_LOGW(TAG, "error reading bytes");

--- a/node/main/time_sync_task.cpp
+++ b/node/main/time_sync_task.cpp
@@ -123,7 +123,10 @@ void time_sync_task(void *pvParameter) {
           // read up to the pattern
           br = uart_read_bytes(UART_NUM, (uint8_t *) buf_read, len, 0);
 
-          ESP_LOGI(TAG, "pat detected %s", buf_read);
+          char * buf_print = buf_read;
+          // drop newline if exists
+          if (*buf_print == '\n') buf_print ++;
+          ESP_LOGD(TAG, "rx from gps: %s", buf_print);
 
           if (br > 0) {
             // leading \n because UART splits on \r


### PR DESCRIPTION
- Start sampling only after time has been synced from the GPS module
- Protect access to the file that samples are written to because it can be accessed from multiple tasks:
  - `sample_write_task`, to actually write samples
  - `mtftp_task`, when the file list is built/client requests read of file