### PR TITLE
Add ability to shutdown node to prevent future writes

### DIFF
--- a/node/main/CMakeLists.txt
+++ b/node/main/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(COMPONENT_REQUIRES )
 set(COMPONENT_PRIV_REQUIRES fatfs ulp common mtftp)
 
-set(COMPONENT_SRCS "main.cpp" "mtftp_task.cpp" "time_sync_task.cpp" "bme280/bme280.c" "sensor.cpp" "sample_task.cpp")
+set(COMPONENT_SRCS "main.cpp" "mtftp_task.cpp" "time_sync_task.cpp" "bme280/bme280.c" "sensor.cpp" "sample_task.cpp" "monitor_task.cpp")
 set(COMPONENT_ADD_INCLUDEDIRS "")
 
 register_component()

--- a/node/main/Kconfig.projbuild
+++ b/node/main/Kconfig.projbuild
@@ -27,4 +27,8 @@ config START_WITHOUT_TIME_SYNC
     bool "Start sampling without waiting for time sync"
     help
         If set, sampling will start without waiting for a time sync
+config BTN_SHUTDOWN_TIME
+    int "Time that btn has to be pressed to shutdown node"
+    default 3000000
+    range 500000 10000000
 endmenu

--- a/node/main/main.cpp
+++ b/node/main/main.cpp
@@ -8,6 +8,7 @@
 #include "mtftp_task.h"
 #include "time_sync_task.h"
 #include "sample_task.h"
+#include "monitor_task.h"
 
 #include "sdkconfig.h"
 
@@ -26,6 +27,7 @@ void app_main(void) {
 
   sd_init();
 
+  xTaskCreate(monitor_task, "monitor_task", 2048, NULL, 3, NULL);
   xTaskCreate(mtftp_task, "mtftp_task", 8192, NULL, 4, NULL);
   xTaskCreate(sample_task, "sample_task", 4096, NULL, 10, NULL);
   xTaskCreate(time_sync_task, "time_sync_task", 4096, NULL, 4, NULL);

--- a/node/main/monitor_task.cpp
+++ b/node/main/monitor_task.cpp
@@ -1,10 +1,22 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_log.h"
 #include "common.h"
 
 #include "monitor_task.h"
 
+QueueHandle_t evt_queue = xQueueCreate(4, 1);
 bool shutdown = false;
+
+// on, period (us)
+const uint32_t led_blink[][2] = {
+  {1000000, 2000000},    // slow blink - waiting for time sync
+  {50000, 3000000},      // periodic blink - standard mode when everything inactive except sampling
+  {100000, 500000},      // fast blink - when transfer
+  {1000000, 1000000}     // full on - shutdown
+};
+
+uint8_t blink_index = 0;
 
 void monitor_task(void *pvParameter) {
   uint64_t btn_press_time = 0;
@@ -22,6 +34,25 @@ void monitor_task(void *pvParameter) {
       btn_press_time = 0;
     }
 
-    vTaskDelay(100 / portTICK_PERIOD_MS);
+    uint8_t evt;
+    if (xQueueReceive(evt_queue, &evt, 50 / portTICK_PERIOD_MS) == pdTRUE) {
+      if (evt == EVT_TIME_SYNCED) {
+        blink_index = 1;
+      } else if (evt == EVT_COMMS_START) {
+        blink_index = 2;
+      } else if (evt == EVT_COMMS_END) {
+        blink_index = 1;
+      } else if (evt == EVT_SHUTDOWN_WRITE_DONE) {
+        blink_index = 3;
+      }
+    }
+
+    int64_t time = esp_timer_get_time();
+
+    if ((time % led_blink[blink_index][1]) < led_blink[blink_index][0]) {
+      set_led(1);
+    } else {
+      set_led(0);
+    }
   }
 }

--- a/node/main/monitor_task.cpp
+++ b/node/main/monitor_task.cpp
@@ -1,0 +1,27 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "common.h"
+
+#include "monitor_task.h"
+
+bool shutdown = false;
+
+void monitor_task(void *pvParameter) {
+  uint64_t btn_press_time = 0;
+
+  while(1) {
+    if (get_btn_user() == 0) {
+      if (btn_press_time == 0) {
+        btn_press_time = esp_timer_get_time();
+      }
+
+      if ((esp_timer_get_time() - btn_press_time) > CONFIG_BTN_SHUTDOWN_TIME) {
+        shutdown = true;
+      }
+    } else {
+      btn_press_time = 0;
+    }
+
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+  }
+}

--- a/node/main/monitor_task.h
+++ b/node/main/monitor_task.h
@@ -1,6 +1,18 @@
 #ifndef MONITOR_TASK_H
 #define MONITOR_TASK_H
 
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+
+typedef enum {
+  EVT_TIME_SYNCED,
+  EVT_COMMS_START,
+  EVT_COMMS_END,
+  EVT_SHUTDOWN_WRITE_DONE
+} Event_t;
+
+extern QueueHandle_t evt_queue;
 extern bool shutdown;
 void monitor_task(void *pvParameter);
 

--- a/node/main/monitor_task.h
+++ b/node/main/monitor_task.h
@@ -1,0 +1,7 @@
+#ifndef MONITOR_TASK_H
+#define MONITOR_TASK_H
+
+extern bool shutdown;
+void monitor_task(void *pvParameter);
+
+#endif

--- a/node/main/mtftp_task.cpp
+++ b/node/main/mtftp_task.cpp
@@ -10,6 +10,7 @@
 
 #include "mtftp_server.hpp"
 #include "sample_task.h"
+#include "monitor_task.h"
 
 #include "mtftp_task.h"
 #include "common.h"
@@ -209,6 +210,9 @@ static void onRecvEspNowCb(const uint8_t *mac_addr, const uint8_t *data, int len
 
       local_state.time_last_packet = esp_timer_get_time();
       received_non_sync = false;
+
+      Event_t evt = EVT_COMMS_START;
+      xQueueSend(evt_queue, &evt, 0);
       return;
     }
   }
@@ -227,6 +231,8 @@ static void onRecvEspNowCb(const uint8_t *mac_addr, const uint8_t *data, int len
 
 static void endPeered(void) {
   const char *TAG = "endPeered";
+  Event_t evt = EVT_COMMS_END;
+  xQueueSend(evt_queue, &evt, 0);
 
   esp_now_del_peer(local_state.peer_addr);
   ESP_LOGI(TAG, "ending peered communication");
@@ -246,34 +252,6 @@ static void endPeered(void) {
   }
 }
 
-static void led_task(void *pvParameter) {
-  // on, period (us)
-  const uint32_t led_blink[][2] = {
-    {50000, 3000000},
-    {100000, 500000}
-  };
-
-  uint8_t blink_index = 0;
-
-  while(1) {
-    if (local_state.state == STATE_WAIT_PEER) {
-      blink_index = 0;
-    } else {
-      blink_index = 1;
-    }
-
-    int64_t time = esp_timer_get_time();
-
-    if ((time % led_blink[blink_index][1]) < led_blink[blink_index][0]) {
-      set_led(1);
-    } else {
-      set_led(0);
-    }
-
-    vTaskDelay(50 / portTICK_PERIOD_MS);
-  }
-}
-
 void mtftp_task(void *pvParameter) {
   const char *TAG = "mtftp_task";
   memset(&local_state, 0, sizeof(local_state));
@@ -283,8 +261,6 @@ void mtftp_task(void *pvParameter) {
 
   server.init(&readFile, &sendEspNow);
   server.setOnTimeoutCb(&endPeered);
-
-  xTaskCreate(led_task, "led_task", 2048, NULL, 3, NULL);
 
   while(1) {
     server.loop();

--- a/node/main/sample_task.cpp
+++ b/node/main/sample_task.cpp
@@ -133,6 +133,8 @@ static void sample_write_task(void *pvParameter) {
 
     if (shutdown) {
       ESP_LOGI(TAG, "sampling shutdown");
+      Event_t evt = EVT_SHUTDOWN_WRITE_DONE;
+      xQueueSend(evt_queue, &evt, 0);
       vTaskSuspend(NULL);
     }
 
@@ -169,6 +171,9 @@ void sample_task(void *pvParameter) {
 #else
   ESP_LOGW(TAG, "skipping wait for time sync because CONFIG_START_WITHOUT_TIME_SYNC is set");
 #endif
+
+  Event_t evt = EVT_TIME_SYNCED;
+  xQueueSend(evt_queue, &evt, 0);
 
   ESP_ERROR_CHECK(ulp_run(&ulp_entry - RTC_SLOW_MEM));
 


### PR DESCRIPTION
- Pressing and holding BTN will trigger a shutdown:
  - Current samples are written to the SD card
  - LED is lit up when write is done

Along with this, the LED on the board now displays more states: waiting for time sync (slow blink) and full on (shutdown)