### PR TITLE
Refactor sampling task

### DIFF
--- a/node/main/main.cpp
+++ b/node/main/main.cpp
@@ -29,6 +29,6 @@ void app_main(void) {
 
   xTaskCreate(monitor_task, "monitor_task", 2048, NULL, 3, NULL);
   xTaskCreate(mtftp_task, "mtftp_task", 8192, NULL, 4, NULL);
-  xTaskCreate(sample_task, "sample_task", 4096, NULL, 10, NULL);
+  xTaskCreate(sample_write_task, "sample_write_task", 4096, NULL, 3, NULL);
   xTaskCreate(time_sync_task, "time_sync_task", 4096, NULL, 4, NULL);
 }

--- a/node/main/sample_task.h
+++ b/node/main/sample_task.h
@@ -5,7 +5,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 
-void sample_task(void *pvParameter);
+void sample_write_task(void *pvParameter);
 
 // this is used to protect access to the file with index sample_file_index
 // because mtftp_task and sample_task could both access it at the same time


### PR DESCRIPTION
Rather than signalling a task from the ULP ISR, starting the sampling directly from the ISR results in far more consistent timing.

Time between every 512 samples (before):
```
time=1601388296021420 sample_size=8 sample_count=512
time=1601388306406898 sample_size=8 sample_count=512
diff=10385478, offset=145478
time=1601388316796651 sample_size=8 sample_count=512
diff=10389753, offset=149753
time=1601388327190172 sample_size=8 sample_count=512
diff=10393521, offset=153521
time=1601388337587270 sample_size=8 sample_count=512
diff=10397098, offset=157098
time=1601388347987399 sample_size=8 sample_count=512
diff=10400129, offset=160129
time=1601388358392323 sample_size=8 sample_count=512
diff=10404924, offset=164924
time=1601388368800168 sample_size=8 sample_count=512
diff=10407845, offset=167845
time=1601388379210963 sample_size=8 sample_count=512
diff=10410795, offset=170795
time=1601388389622014 sample_size=8 sample_count=512
diff=10411051, offset=171051
time=1601388400035962 sample_size=8 sample_count=512
diff=10413948, offset=173948
time=1601388410452579 sample_size=8 sample_count=512
diff=10416617, offset=176617
time=1601388420871785 sample_size=8 sample_count=512
diff=10419206, offset=179206
time=1601388431293611 sample_size=8 sample_count=512
diff=10421826, offset=181826
time=1601388441717741 sample_size=8 sample_count=512
diff=10424130, offset=184130
time=1601388452142357 sample_size=8 sample_count=512
diff=10424616, offset=184616
time=1601388462567765 sample_size=8 sample_count=512
diff=10425408, offset=185408
time=1601388472996384 sample_size=8 sample_count=512
diff=10428619, offset=188619
time=1601388483426484 sample_size=8 sample_count=512
diff=10430100, offset=190100
time=1601388493858208 sample_size=8 sample_count=512
diff=10431724, offset=191724
time=1601388504290993 sample_size=8 sample_count=512
diff=10432785, offset=192785
time=1601388514725902 sample_size=8 sample_count=512
diff=10434909, offset=194909
time=1601388525162955 sample_size=8 sample_count=512
diff=10437053, offset=197053
time=1601388535600085 sample_size=8 sample_count=512
diff=10437130, offset=197130
time=1601388546037135 sample_size=8 sample_count=512
diff=10437050, offset=197050
time=1601388556475437 sample_size=8 sample_count=172
diff=10438302, offset=198302
```

Time between every 512 samples (after):
```
time=1601561887021065 sample_size=8 sample_count=512
time=1601561897353730 sample_size=8 sample_count=512
diff=10332665, offset=92665
time=1601561907685614 sample_size=8 sample_count=512
diff=10331884, offset=91884
time=1601561918016387 sample_size=8 sample_count=512
diff=10330773, offset=90773
time=1601561928346234 sample_size=8 sample_count=512
diff=10329847, offset=89847
time=1601561938677267 sample_size=8 sample_count=512
diff=10331033, offset=91033
time=1601561949008694 sample_size=8 sample_count=512
diff=10331427, offset=91427
time=1601561959340264 sample_size=8 sample_count=512
diff=10331570, offset=91570
time=1601561969672484 sample_size=8 sample_count=512
diff=10332220, offset=92220
time=1601561980003803 sample_size=8 sample_count=512
diff=10331319, offset=91319
time=1601561990337860 sample_size=8 sample_count=512
diff=10334057, offset=94057
time=1601562000670393 sample_size=8 sample_count=512
diff=10332533, offset=92533
time=1601562010999660 sample_size=8 sample_count=512
diff=10329267, offset=89267
time=1601562021332584 sample_size=8 sample_count=512
diff=10332924, offset=92924
time=1601562031664752 sample_size=8 sample_count=512
diff=10332168, offset=92168
time=1601562041995916 sample_size=8 sample_count=512
diff=10331164, offset=91164
time=1601562052327679 sample_size=8 sample_count=512
diff=10331763, offset=91763
time=1601562062660061 sample_size=8 sample_count=512
diff=10332382, offset=92382
time=1601562072990960 sample_size=8 sample_count=512
diff=10330899, offset=90899
time=1601562083321449 sample_size=8 sample_count=512
diff=10330489, offset=90489
time=1601562090653535 sample_size=8 sample_count=512
diff=7332086, offset=-2907914
time=1601562100987119 sample_size=8 sample_count=512
diff=10333584, offset=93584
time=1601562111318813 sample_size=8 sample_count=512
diff=10331694, offset=91694
time=1601562121650816 sample_size=8 sample_count=316
diff=10332003, offset=92003
```